### PR TITLE
fix variable names in satellite-answers.yaml for admin username/password

### DIFF
--- a/templates/satellite-answers.yaml
+++ b/templates/satellite-answers.yaml
@@ -12,8 +12,8 @@ certs:
   deploy: true
   group: foreman
 foreman:
-  admin_username: {{ satellite_admin_username }}
-  admin_password: {{ satellite_admin_password }}
+  initial_admin_username: {{ satellite_admin_username }}
+  initial_admin_password: {{ satellite_admin_password }}
   initial_organization: {{ satellite_organization }}
   initial_location: {{ satellite_location }}
   ssl: {{ satellite_enable_ssl }}


### PR DESCRIPTION
Satellite admin/user not getting set correctly.  Dug into the issue and found that the variable names should include "initial_" like org and location.  Tested locally, works as expected.